### PR TITLE
Add compute_eigensystems parameter to opt out of eigendecomposition

### DIFF
--- a/pykarambola/api.py
+++ b/pykarambola/api.py
@@ -266,9 +266,15 @@ def minkowski_functionals_from_label_image(
         ``None``: use the origin.
         ``(3,)`` array: use an explicit point for all labels.
     compute : str or list of str
-        Passed through to :func:`minkowski_functionals`.
+        Which functionals to compute. ``'standard'`` returns the 14 base
+        functionals; ``'all'`` additionally computes ``w103``, ``w104``,
+        and spherical Minkowski summaries (``msm_ql``, ``msm_wl``); a list
+        of names selects specific quantities.
     compute_eigensystems : bool, optional
-        Passed through to :func:`minkowski_functionals`.
+        If False, eigenvalues and eigenvectors for rank-2 tensors are
+        skipped (``*_eigvals`` / ``*_eigvecs`` keys are omitted from each
+        label's result dict), avoiding six ``np.linalg.eigh`` calls per
+        label. Default is True.
 
     Returns
     -------

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -237,7 +237,23 @@ class TestComputeEigensystems:
             assert f'{name}_eigvals' in result
             assert f'{name}_eigvecs' in result
 
+    def test_single_rank2_tensor_omits_eigensystem(self):
+        # Requesting a single rank-2 tensor with compute_eigensystems=False
+        # should return the tensor matrix but suppress its eigvals/eigvecs.
+        result = minkowski_functionals(
+            self.verts, self.faces,
+            compute=['w102'],
+            compute_eigensystems=False,
+        )
+        assert 'w102' in result
+        assert result['w102'].shape == (3, 3)
+        assert 'w102_eigvals' not in result
+        assert 'w102_eigvecs' not in result
+
     def test_beta_with_false_raises_value_error(self):
+        # 'beta' is not yet implemented as a functional, but the guard fires
+        # proactively as a forward-compatibility check so that once beta lands
+        # it cannot be requested without eigensystems.
         with pytest.raises(ValueError, match="compute_eigensystems=True"):
             minkowski_functionals(
                 self.verts, self.faces,
@@ -246,6 +262,7 @@ class TestComputeEigensystems:
             )
 
     def test_beta_suffix_with_false_raises_value_error(self):
+        # Same forward-compatibility guard for any *_beta quantity.
         with pytest.raises(ValueError, match="compute_eigensystems=True"):
             minkowski_functionals(
                 self.verts, self.faces,


### PR DESCRIPTION
Resolves #51.

## Summary

- Adds `compute_eigensystems=True` to `minkowski_functionals()` and `minkowski_functionals_from_label_image()`. Default keeps existing behaviour unchanged.
- When `False`, rank-2 tensor matrices (3×3) are still computed and returned — only the eigendecomposition (`*_eigvals` / `*_eigvecs` keys) is skipped, avoiding six `np.linalg.eigh` calls per label.
- Raises `ValueError` if any beta-derived quantity (e.g. `'beta'`, `'w020_beta'`) is requested alongside `compute_eigensystems=False`, anticipating the hard dependency introduced by #1.

## Test plan

- [ ] `compute_eigensystems=False` omits `*_eigvals` / `*_eigvecs` from output
- [ ] `compute_eigensystems=False` still returns raw 3×3 tensor matrices
- [ ] `compute_eigensystems=False` works cleanly with scalar-only `compute` lists
- [ ] `compute_eigensystems=True` (default) preserves existing eigensystem output
- [ ] `beta` + `compute_eigensystems=False` raises `ValueError` with clear message
- [ ] `*_beta` suffix + `compute_eigensystems=False` raises `ValueError`
- [ ] `minkowski_functionals_from_label_image` threads the parameter through correctly
- [ ] All 35 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)