### PR TITLE
Fix numeric safety: zero-denominator guards in minkowski.py (#42, #43…

### DIFF
--- a/pykarambola/api.py
+++ b/pykarambola/api.py
@@ -338,7 +338,16 @@ def minkowski_functionals_from_label_image(
             v1c = verts[faces[:, 1]]
             v2c = verts[faces[:, 2]]
             d = np.einsum('ij,ij->i', v0c, np.cross(v1c - v0c, v2c - v0c))
-            label_center = np.einsum('i,ij->j', d, v0c + v1c + v2c) / (4.0 * d.sum())
+            d_sum = d.sum()
+            if abs(d_sum) < 1e-12:
+                warnings.warn(
+                    f"Mesh centroid denominator near zero for label {lab}; "
+                    "falling back to origin reference.",
+                    stacklevel=2,
+                )
+                label_center = np.zeros(3)
+            else:
+                label_center = np.einsum('i,ij->j', d, v0c + v1c + v2c) / (4.0 * d_sum)
         elif isinstance(center, str) and center == 'centroid_voxel':
             voxel_coords = np.argwhere(label_image == lab)  # (N, 3)
             label_center = voxel_coords.mean(axis=0) * np.array(spacing)

--- a/pykarambola/minkowski.py
+++ b/pykarambola/minkowski.py
@@ -39,7 +39,7 @@ def _default_rank4():
     return MinkValResult(result=SymmetricRank4Tensor())
 
 
-def get_ref_vec(label, w_scalar, w_vector, eps=1e-12):
+def get_ref_vec(label, w_scalar, w_vector, eps=1e-12, denominator_name=None):
     """Compute reference vector (centroid) = w_vector / w_scalar for a label.
 
     Falls back to the origin and emits a warning when the scalar denominator
@@ -48,8 +48,9 @@ def get_ref_vec(label, w_scalar, w_vector, eps=1e-12):
     """
     s = w_scalar[label].result
     if abs(s) < eps:
+        hint = f" ({denominator_name})" if denominator_name else ""
         warnings.warn(
-            f"Scalar denominator near zero for label {label}; "
+            f"Scalar denominator{hint} near zero for label {label}; "
             "falling back to origin reference.",
             stacklevel=3,
         )
@@ -109,10 +110,10 @@ def calculate_w300(surface):
 
     # Guard: vertices with zero angle sum (isolated or fully degenerate triangles)
     # contribute nothing to the Gaussian curvature integral.
-    if np.any(surface._vertex_angle_sums == 0):
+    if np.any(surface._vertex_angle_sums <= 0):
         warnings.warn(
-            "Mesh contains vertices with zero angle sum (isolated or degenerate "
-            "triangles); their Gaussian curvature contribution is set to zero.",
+            "Mesh contains vertices with zero or negative angle sum (isolated or "
+            "degenerate triangles); their Gaussian curvature contribution is set to zero.",
             stacklevel=2,
         )
 
@@ -207,6 +208,13 @@ def calculate_w210(surface):
 
 def calculate_w310(surface):
     """Gaussian curvature-weighted position via angle deficit."""
+    if np.any(surface._vertex_angle_sums <= 0):
+        warnings.warn(
+            "Mesh contains vertices with zero or negative angle sum (isolated or "
+            "degenerate triangles); their contribution is set to zero.",
+            stacklevel=2,
+        )
+
     F = surface.n_triangles()
     result_vals = np.zeros((F, 3), dtype=np.float64)
 
@@ -248,7 +256,7 @@ def calculate_w020(surface, w000=None, w010=None):
     ref_vecs = {}
     for lab in label_groups:
         if w000 and len(w000) > 0 and lab in w000:
-            ref_vecs[lab] = get_ref_vec(lab, w000, w010)
+            ref_vecs[lab] = get_ref_vec(lab, w000, w010, denominator_name='w000')
         else:
             ref_vecs[lab] = np.zeros(3)
 
@@ -330,7 +338,7 @@ def calculate_w120(surface, w100=None, w110=None):
     ref_vecs = {}
     for lab in label_groups:
         if w100 and len(w100) > 0 and lab in w100:
-            ref_vecs[lab] = get_ref_vec(lab, w100, w110)
+            ref_vecs[lab] = get_ref_vec(lab, w100, w110, denominator_name='w100')
         else:
             ref_vecs[lab] = np.zeros(3)
 
@@ -363,7 +371,7 @@ def calculate_w220(surface, w200=None, w210=None):
     ref_vecs = {}
     for lab in label_groups:
         if w200 and len(w200) > 0 and lab in w200:
-            ref_vecs[lab] = get_ref_vec(lab, w200, w210)
+            ref_vecs[lab] = get_ref_vec(lab, w200, w210, denominator_name='w200')
         else:
             ref_vecs[lab] = np.zeros(3)
 
@@ -399,13 +407,20 @@ def calculate_w220(surface, w200=None, w210=None):
 
 def calculate_w320(surface, w300=None, w310=None):
     """Gaussian curvature-weighted tensor product via angle deficit."""
+    if np.any(surface._vertex_angle_sums <= 0):
+        warnings.warn(
+            "Mesh contains vertices with zero or negative angle sum (isolated or "
+            "degenerate triangles); their contribution is set to zero.",
+            stacklevel=2,
+        )
+
     results = {}
     label_groups = _group_by_label(surface._labels)
 
     ref_vecs = {}
     for lab in label_groups:
         if w300 and len(w300) > 0 and lab in w300:
-            ref_vecs[lab] = get_ref_vec(lab, w300, w310)
+            ref_vecs[lab] = get_ref_vec(lab, w300, w310, denominator_name='w300')
         else:
             ref_vecs[lab] = np.zeros(3)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -215,11 +215,12 @@ class TestNumericSafety:
 
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            result = get_ref_vec(0, w_scalar, w_vector)
+            result = get_ref_vec(0, w_scalar, w_vector, denominator_name='w300')
 
         assert len(w) == 1
         assert issubclass(w[0].category, UserWarning)
         assert "near zero" in str(w[0].message).lower()
+        assert "w300" in str(w[0].message)
         np.testing.assert_array_equal(result, [0.0, 0.0, 0.0])
 
     def test_get_ref_vec_nonzero_scalar_returns_correct_value(self):
@@ -232,11 +233,18 @@ class TestNumericSafety:
         result = get_ref_vec(0, w_scalar, w_vector)
         np.testing.assert_array_almost_equal(result, [2.0, 3.0, 4.0])
 
-    def test_w300_zero_angle_sum_no_nan_and_warns(self):
-        """#43: calculate_w300 handles a vertex with angle_sum==0 without NaN/crash."""
+    @pytest.mark.parametrize("fn_name", [
+        "calculate_w300",
+        "calculate_w310",
+        "calculate_w320",
+    ])
+    def test_zero_angle_sum_no_nan_and_warns(self, fn_name):
+        """#43: w300/w310/w320 handle a vertex with angle_sum<=0 without NaN/crash and emit a warning."""
         import warnings
+        import pykarambola.minkowski as mink
         from pykarambola.triangulation import Triangulation
-        from pykarambola.minkowski import calculate_w300
+
+        fn = getattr(mink, fn_name)
 
         verts, faces = _box_mesh(2.0, 3.0, 4.0)
         surf = Triangulation.from_arrays(verts, faces)
@@ -244,23 +252,15 @@ class TestNumericSafety:
 
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            result = calculate_w300(surf)
+            result = fn(surf)
 
         assert any(issubclass(warning.category, UserWarning) for warning in w)
-        assert np.isfinite(result[0].result)
 
-    def test_w320_zero_angle_sum_no_nan(self):
-        """#43: calculate_w320 handles a vertex with angle_sum==0 without NaN/crash."""
-        from pykarambola.triangulation import Triangulation
-        from pykarambola.minkowski import calculate_w320
-
-        verts, faces = _box_mesh(2.0, 3.0, 4.0)
-        surf = Triangulation.from_arrays(verts, faces)
-        surf._vertex_angle_sums[0] = 0.0
-
-        result = calculate_w320(surf)
-        for i_idx, j_idx in [(0, 0), (1, 0), (1, 1), (2, 0), (2, 1), (2, 2)]:
-            assert np.isfinite(result[0].result[i_idx, j_idx])
+        from pykarambola.tensor import SymmetricMatrix3
+        for val in result.values():
+            r = val.result
+            arr = r.to_numpy() if isinstance(r, SymmetricMatrix3) else np.atleast_1d(r)
+            assert np.all(np.isfinite(arr.astype(float)))
 
     def test_w320_centroid_zero_w300_warns_and_falls_back(self):
         """#49: w320 with center='centroid' and w300==0 (torus) falls back to origin."""


### PR DESCRIPTION
## Summary

Fixes three related silent division-by-zero bugs in `minkowski.py`, all rooted in missing guards around denominators that can be zero for valid but degenerate or unusual mesh inputs.

- **#42** — `get_ref_vec` divided `w_vector / w_scalar` unconditionally. For open surfaces, flat surfaces, or zero-area labels the scalar is zero, producing silent `inf`/`nan`.
- **#43** — `calculate_w300`, `calculate_w310`, and `calculate_w320` computed `angle / angle_sum` without guarding against `angle_sum == 0`, which occurs for isolated vertices or vertices whose incident triangles are all degenerate.
- **#49** — `calculate_w320` with `center='centroid'` calls `get_ref_vec(lab, w300, w310)`. For toroidal surfaces the Euler characteristic is zero so `w300 = 0`, triggering the same unguarded division as #42. Resolved as a side-effect of the #42 fix.

## Changes

**`pykarambola/minkowski.py`**

- `get_ref_vec`: added `eps=1e-12` guard — when `|s| < eps`, emits a `UserWarning` and returns `np.zeros(3)` instead of dividing by zero.
- `calculate_w300`: replaced bare `angle / angle_sum` with `np.where(angle_sum > 0, ..., 0.0)`; emits a single `UserWarning` if any zero-sum vertex is detected.
- `calculate_w310`, `calculate_w320`: same `np.where` guard, silently (warning already covered by `calculate_w300` / `get_ref_vec`).

**`tests/test_api.py`**

Added `TestNumericSafety` with 5 tests:
- `test_get_ref_vec_near_zero_scalar_warns_and_returns_zeros` — verifies warning + zero fallback for #42
- `test_get_ref_vec_nonzero_scalar_returns_correct_value` — normal-path regression
- `test_w300_zero_angle_sum_no_nan_and_warns` — patches `_vertex_angle_sums[0] = 0` on a real surface, checks no NaN and warning emitted (#43)
- `test_w320_zero_angle_sum_no_nan` — same for `calculate_w320` (#43)
- `test_w320_centroid_zero_w300_warns_and_falls_back` — simulates toroidal `w300 = 0` via mock `MinkValResult`, verifies no crash and warning emitted (#49)

## Test plan

- [ ] All 84 existing tests continue to pass (`pytest`)
- [ ] `TestNumericSafety` (5 new tests) all pass
- [ ] No `nan` or `inf` produced when `get_ref_vec` is called with a near-zero scalar
- [ ] No `nan` or `inf` produced when `calculate_w300`/`calculate_w320` encounter a vertex with `angle_sum == 0`

Closes #42, #43, #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)