### PR TITLE
SEO: surface description before banner, add Documentation URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@
 [![PyPI version](https://img.shields.io/pypi/v/pykarambola)](https://pypi.org/project/pykarambola/)
 [![Python versions](https://img.shields.io/pypi/pyversions/pykarambola)](https://pypi.org/project/pykarambola/)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
-<p align="center">
-  <img src="assets/banner.png" alt="pykarambola" width="75%"/>
-</p>
 
 **pykarambola** computes Minkowski tensors for 3D objects represented as triangulated meshes — a family of shape descriptors rooted in integral geometry that rigorously quantify size, shape, and orientation.
+
+<p align="center">
+  <img src="assets/banner.png" alt="pykarambola — Minkowski tensor morphometry of 3D triangulated surfaces" width="75%"/>
+</p>
+
 Given a mesh, it returns scalar, vector, and tensor quantities including volume, surface area, integrated mean curvature, and Euler characteristic (the Minkowski functionals), as well as higher-rank tensors that capture anisotropy and preferred orientation independently of coordinate frame.
 pykarambola is a Python implementation of [karambola](https://github.com/morphometry/karambola), the reference C++ package for Minkowski tensor computation on 3D triangulated surfaces.
 Minkowski tensors are widely applicable to analyzing 3D structures in biomedical imaging, computational physics, and materials science.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://github.com/Ishihara-SynthMorph/pykarambola"
+Documentation = "https://github.com/Ishihara-SynthMorph/pykarambola#readme"
 "Bug Tracker" = "https://github.com/Ishihara-SynthMorph/pykarambola/issues"
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

- Move opening description paragraph above the banner image in README so Google indexes it as the page snippet
- Improve banner `alt` text to be descriptive
- Add `Documentation` URL to `[project.urls]` in `pyproject.toml` so it appears as a sidebar link on the PyPI page

## Test plan

- [ ] Verify README renders correctly on GitHub (description visible before image)
- [ ] After next PyPI release, confirm Documentation link appears on the PyPI sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)