### PR TITLE
paper: Results §Label-image API walkthrough (closes #33)

### DIFF
--- a/examples/label_image_api.ipynb
+++ b/examples/label_image_api.ipynb
@@ -625,6 +625,12 @@
     "- **`autolabel=True`**: the function ignores label values and detects connected components on the mesh internally — no preprocessing with `scipy.ndimage.label` required. Results are identical to Case 3.\n",
     "- **Case 2**: per-compartment comparison shows DNA objects and the whole cell body have different anisotropy signatures. Using separate calls ensures the cell body measurement is not truncated to cytoplasm.\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3feebc5d",
+   "metadata": {},
+   "source": []
   }
  ],
  "metadata": {

--- a/examples/label_image_api.ipynb
+++ b/examples/label_image_api.ipynb
@@ -30,7 +30,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 32,
    "id": "f5ee5154",
    "metadata": {
     "execution": {
@@ -64,7 +64,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 33,
    "id": "b1fe0e23",
    "metadata": {
     "execution": {
@@ -105,7 +105,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 34,
    "id": "71458925",
    "metadata": {
     "execution": {
@@ -154,7 +154,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 35,
    "id": "3cc4328d",
    "metadata": {
     "execution": {
@@ -194,7 +194,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 36,
    "id": "25225cf6",
    "metadata": {
     "execution": {
@@ -238,7 +238,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 37,
    "id": "d0db0804",
    "metadata": {
     "execution": {
@@ -281,7 +281,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 38,
    "id": "e04a0fbf",
    "metadata": {
     "execution": {
@@ -331,7 +331,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 39,
    "id": "c12febba",
    "metadata": {
     "execution": {
@@ -384,7 +384,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 40,
    "id": "4ba23e94",
    "metadata": {
     "execution": {
@@ -447,6 +447,79 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c44xs7pezfd",
+   "metadata": {},
+   "source": [
+    "## Case 3 — Alternative: `autolabel=True` (built-in connected-component detection)\n",
+    "\n",
+    "`minkowski_tensors_from_label_image` can also detect connected components **internally** without a prior call to `scipy.ndimage.label`.\n",
+    "When `autolabel=True`, the function ignores label values, treats the image as binary, builds a single mesh from all non-zero voxels, and runs connected-component detection on the resulting triangulation — equivalent to `minkowski_tensors(..., labels='auto')`.\n",
+    "\n",
+    "This is a one-call alternative to the two-step `ndimage.label` → `minkowski_tensors_from_label_image` pattern used in Case 3.\n",
+    "The per-object tensors should be identical; the only difference is key naming: results are keyed by **0-based component index** instead of the label values assigned by `ndimage.label`.\n",
+    "\n",
+    "> **Note on indexing:** `autolabel=True` keys components by detection order on the mesh (0-based), which may differ from the `ndimage.label` order (1-based). The comparison below aligns objects by volume.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "id": "3e2bn1o3j6w",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "autolabel=True  → 3 objects, keys: [1, 2, 3]\n",
+      "ndimage.label   → 3 objects,  keys: [1, 2, 3]\n",
+      "\n",
+      "Rank     ndimage vol (µm³)   autolabel vol (µm³)       Δvol   ndimage β   autolabel β       Δβ\n",
+      "--------------------------------------------------------------------------------------------\n",
+      "1                  55.8136               55.8136   0.00e+00      0.1935        0.1935 0.00e+00\n",
+      "2                  27.0975               27.0975   0.00e+00      0.1439        0.1439 0.00e+00\n",
+      "3                  26.8205               26.8205   0.00e+00      0.1514        0.1514 0.00e+00\n",
+      "\n",
+      "All volumes match:  True\n",
+      "All β match:        True\n"
+     ]
+    }
+   ],
+   "source": [
+    "# autolabel=True: pykarambola detects components internally — no scipy.ndimage.label needed\n",
+    "results_case3_auto = pk.minkowski_tensors_from_label_image(\n",
+    "    dna_mask.astype(int), autolabel=True, compute=\"all\"\n",
+    ")\n",
+    "\n",
+    "print(f'autolabel=True  → {len(results_case3_auto)} objects, keys: {sorted(results_case3_auto)}')\n",
+    "print(f'ndimage.label   → {len(results_case3)} objects,  keys: {sorted(results_case3)}')\n",
+    "\n",
+    "# Align objects by descending volume (largest first) to compare regardless of key ordering\n",
+    "def sorted_by_volume(results):\n",
+    "    return sorted(results.values(), key=lambda r: r['w000'], reverse=True)\n",
+    "\n",
+    "case3_sorted = sorted_by_volume(results_case3)\n",
+    "auto_sorted  = sorted_by_volume(results_case3_auto)\n",
+    "\n",
+    "print(f'\\n{\"Rank\":<6} {\"ndimage vol (µm³)\":>19} {\"autolabel vol (µm³)\":>21} '\n",
+    "      f'{\"Δvol\":>10} {\"ndimage β\":>11} {\"autolabel β\":>13} {\"Δβ\":>8}')\n",
+    "print('-' * 92)\n",
+    "for i, (r3, ra) in enumerate(zip(case3_sorted, auto_sorted)):\n",
+    "    vol3  = r3['w000'] * voxel_size_um**3\n",
+    "    vola  = ra['w000'] * voxel_size_um**3\n",
+    "    beta3 = r3['w020_beta']\n",
+    "    betaa = ra['w020_beta']\n",
+    "    print(f'{i+1:<6} {vol3:>19.4f} {vola:>21.4f} {vol3-vola:>10.2e} '\n",
+    "          f'{beta3:>11.4f} {betaa:>13.4f} {beta3-betaa:>8.2e}')\n",
+    "\n",
+    "vol_match  = all(abs(r3['w000']      - ra['w000'])      < 1e-8 for r3, ra in zip(case3_sorted, auto_sorted))\n",
+    "beta_match = all(abs(r3['w020_beta'] - ra['w020_beta']) < 1e-8 for r3, ra in zip(case3_sorted, auto_sorted))\n",
+    "print(f'\\nAll volumes match:  {vol_match}')\n",
+    "print(f'All β match:        {beta_match}')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "3e7d96ab",
    "metadata": {},
    "source": [
@@ -470,7 +543,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 42,
    "id": "7cb0d1a0",
    "metadata": {
     "execution": {
@@ -539,14 +612,17 @@
     "\n",
     "The same binary segmentation yields fundamentally different measurements depending on how labels are assigned:\n",
     "\n",
-    "| Case | Input | `minkowski_tensors_from_label_image` call | Output |\n",
-    "|------|-------|------------------------------------------|--------|\n",
-    "| 1 | Cell body mask | `(cell_mask)` as label 1 | One result — whole cell |\n",
-    "| 2 | Two channels, separate calls | one call per channel | Two results — per channel (whole) |\n",
-    "| 3 | DNA mask → `scipy.ndimage.label` | `(label_case3)` | N results — per DNA object |\n",
+    "| Case | Input to function | Key argument | Output |\n",
+    "|------|-------------------|--------------|--------|\n",
+    "| 1 | `cell_mask.astype(int)` — single label | `autolabel=False` (default) | 1 result — whole cell |\n",
+    "| 2 | `dna_mask.astype(int)` or `cell_mask.astype(int)` — one call per channel | `autolabel=False` (default) | 1 result per call (whole compartment) |\n",
+    "| 3 | `ndimage.label(dna_mask)` — pre-labeled integer image | `autolabel=False` (default) | N results — per DNA object |\n",
+    "| 3 (alt) | `dna_mask.astype(int)` — raw binary mask | `autolabel=True` | N results — per DNA object (identical to Case 3) |\n",
     "\n",
     "Key observations:\n",
-    "- **Case 1 vs Case 3**: same DNA binary mask, but Case 1 treats all DNA objects as one (measures total volume/shape) while Case 3 resolves each DNA object individually.\n",
+    "- **Case 1 vs Case 3**: same DNA binary mask, but Case 1 (`autolabel=False`, single label value) treats all DNA objects as one body while Case 3 resolves each individually.\n",
+    "- **`autolabel=False` (default)**: the function trusts the label values you provide. A binary mask has one nonzero label → one result. A pre-labeled integer image has N labels → N results.\n",
+    "- **`autolabel=True`**: the function ignores label values and detects connected components on the mesh internally — no preprocessing with `scipy.ndimage.label` required. Results are identical to Case 3.\n",
     "- **Case 2**: per-compartment comparison shows DNA objects and the whole cell body have different anisotropy signatures. Using separate calls ensures the cell body measurement is not truncated to cytoplasm.\n"
    ]
   }

--- a/paper/manuscript.tex
+++ b/paper/manuscript.tex
@@ -145,7 +145,19 @@ The residual discrepancies observed in non-near-zero features arise from differe
 \end{figure}
 
 \subsection*{Label-image API walkthrough}
-% TODO (issue #33)
+To demonstrate the label-image API, we applied \texttt{minkowski\_tensors\_from\_label\_image} to a publicly available 3D fluorescence segmentation of a human induced pluripotent stem cell (hiPSC) in early anaphase/telophase from the Allen Cell Collection~\cite{Viana2020}.
+The segmentation provides a two-channel binary mask at isotropic voxel spacing of 0.108~$\mu$m: one channel for the DNA (nucleus) and one for the cell body.
+
+Figure~\ref{fig:labelimage} illustrates how the choice of labelling scheme directly determines what the tensors measure, using the DNA channel as a concrete example.
+In case~(i), the entire DNA channel is passed as a single binary mask; \texttt{minkowski\_tensors\_from\_label\_image} returns one tensor set describing the aggregate geometry of all chromosomal material ($V = 110~\mu\text{m}^3$, $A = 435~\mu\text{m}^2$, $\chi = 2$, $\beta_0^{2,0} = 0.118$).
+In case~(ii), \texttt{scipy.ndimage.label} first assigns a unique integer label to each connected component, and \texttt{minkowski\_tensors\_from\_label\_image} returns three independent tensor sets --- one per DNA object.
+The per-object results reveal structure that is invisible in case~(i): object~1 ($V = 56~\mu\text{m}^3$, $\beta_0^{2,0} = 0.194$) is approximately twice the volume of objects~2 and~3 ($V \approx 27~\mu\text{m}^3$ each), which are more elongated ($\beta_0^{2,0} \approx 0.144$--$0.151$), consistent with sister chromatids caught mid-separation.
+The anisotropy of the DNA objects is substantially higher than that of the cell body ($\beta_0^{2,0} = 0.277$).
+
+This example demonstrates a general principle: identical binary image data yields fundamentally different morphometric results depending on label assignment, and the correct choice depends on the biological question.
+Whole-structure morphometry (case~i) is appropriate when the aggregate shape is the object of interest; per-object morphometry (case~ii) is required when individual instances must be resolved, as in cell counting, organelle tracking, or shape clustering.
+Both modes are supported by a single function call; the full worked example including mesh visualisation and Minkowski tensor additivity is provided in the accompanying notebook (notebook~\#17, Supplementary Material).
+The pipeline from label image to triangulated mesh and Minkowski tensors is summarised in Figure~\ref{fig:pipeline}; the pykarambola output is directly compatible with standard bioimage segmentation tools such as cellpose~\cite{Stringer2021cellpose} and StarDist~\cite{Schmidt2018stardist}, whose instance segmentation outputs are integer label images of precisely the form accepted by \texttt{minkowski\_tensors\_from\_label\_image}.
 
 \begin{figure}
 \centering

--- a/paper/manuscript.tex
+++ b/paper/manuscript.tex
@@ -149,8 +149,9 @@ To demonstrate the label-image API, we applied \texttt{minkowski\_tensors\_from\
 The segmentation provides a two-channel binary mask at isotropic voxel spacing of 0.108~$\mu$m: one channel for the DNA (nucleus) and one for the cell body.
 
 Figure~\ref{fig:labelimage} illustrates how the choice of labelling scheme directly determines what the tensors measure, using the DNA channel as a concrete example.
-In case~(i), the entire DNA channel is passed as a single binary mask; \texttt{minkowski\_tensors\_from\_label\_image} returns one tensor set describing the aggregate geometry of all chromosomal material ($V = 110~\mu\text{m}^3$, $A = 435~\mu\text{m}^2$, $\chi = 2$, $\beta_0^{2,0} = 0.118$).
-In case~(ii), \texttt{scipy.ndimage.label} first assigns a unique integer label to each connected component, and \texttt{minkowski\_tensors\_from\_label\_image} returns three independent tensor sets --- one per DNA object.
+In case~(i), the binary DNA mask is cast to an integer array (\texttt{dna\_mask.astype(int)}) and passed with the default \texttt{autolabel=False}; because all non-zero voxels share label value~1, the function returns one tensor set describing the aggregate geometry of all chromosomal material ($V = 110~\mu\text{m}^3$, $A = 435~\mu\text{m}^2$, $\chi = 2$, $\beta_0^{2,0} = 0.118$).
+In case~(ii), \texttt{scipy.ndimage.label(dna\_mask)} first assigns a unique integer to each connected component; the resulting three-valued label image is passed with \texttt{autolabel=False} (default), and the function returns three independent tensor sets --- one per DNA object.
+Equivalently, case~(ii) can be achieved in a single call by passing the binary mask with \texttt{autolabel=True}, which instructs the function to detect connected components on the mesh internally without any preprocessing; the per-object tensors are numerically identical.
 The per-object results reveal structure that is invisible in case~(i): object~1 ($V = 56~\mu\text{m}^3$, $\beta_0^{2,0} = 0.194$) is approximately twice the volume of objects~2 and~3 ($V \approx 27~\mu\text{m}^3$ each), which are more elongated ($\beta_0^{2,0} \approx 0.144$--$0.151$), consistent with sister chromatids caught mid-separation.
 The anisotropy of the DNA objects is substantially higher than that of the cell body ($\beta_0^{2,0} = 0.277$).
 

--- a/paper/references.bib
+++ b/paper/references.bib
@@ -1,3 +1,30 @@
+@article{Viana2020,
+    title = {Integrated intracellular organization and its variations in human iPS cells},
+    author = {Viana, Matheus P and Chen, Jianxu and Knijnenburg, Theo A and others},
+    journal = {bioRxiv},
+    year = {2020},
+    doi = {10.1101/2020.12.08.415562},
+}
+
+@article{Stringer2021cellpose,
+    title = {Cellpose: a generalist algorithm for cellular segmentation},
+    author = {Stringer, Carsen and Wang, Tim and Michaelos, Michalis and Pachitariu, Marius},
+    journal = {Nature Methods},
+    volume = {18},
+    pages = {100--106},
+    year = {2021},
+    doi = {10.1038/s41592-020-01018-x},
+}
+
+@inproceedings{Schmidt2018stardist,
+    title = {Cell detection with star-convex polygons},
+    author = {Schmidt, Uwe and Weigert, Martin and Broaddus, Coleman and Myers, Gene},
+    booktitle = {Medical Image Computing and Computer Assisted Intervention (MICCAI)},
+    pages = {265--273},
+    year = {2018},
+    doi = {10.1007/978-3-030-00934-2_30},
+}
+
 @article{SchroderTurk2013,
     title = {Minkowski tensors of anisotropic spatial structure},
     year = {2013},


### PR DESCRIPTION
## Summary

- Writes the `\subsection*{Label-image API walkthrough}` section in `paper/manuscript.tex` (closes #33)
- Adds three missing bibliography entries to `paper/references.bib`: `Viana2020`, `Stringer2021cellpose`, `Schmidt2018stardist`

## What the section covers

- Introduces the AllenCell hiPSC anaphase/telophase segmentation as the worked example
- Case (i): entire DNA channel as one label — reports aggregate V, A, χ, β₀^{2,0}
- Case (ii): per-object via `scipy.ndimage.label` — reports per-object values and interprets the biological meaning (sister chromatids mid-separation)
- Explains the general principle: label assignment determines what the tensors measure
- References `fig:labelimage` (#21), `fig:pipeline` (#18), and notebook #17
- Notes compatibility with cellpose and StarDist instance segmentation outputs

## Test plan
- [ ] Check section compiles cleanly in LaTeX
- [ ] Verify all `\cite{}` keys resolve in `references.bib`
- [ ] Confirm numerical values match `examples/label_image_api.ipynb` outputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)