### PR TITLE
paper: software and data availability statements (closes #36)

### DIFF
--- a/paper/manuscript.tex
+++ b/paper/manuscript.tex
@@ -118,7 +118,7 @@ It extracts a triangulated isosurface for each label via \texttt{scikit-image} m
 We benchmarked pykarambola against the reference C++ karambola binary on two mesh sets.
 First, synthetic icospheres at subdivision levels 5–10 (10{,}242 to 10{,}485{,}762 vertices) were used to characterise runtime scaling; both the pure-Python build and the Cython-accelerated build were timed independently (see Acceleration strategy, Methods).
 Second, the AdrenalMNIST3D a standardized biomedical dataset~\cite{Yang2023MedMNIST} with 1{,}584 adrenal glands at two voxel resolutions (28$^3$ and 64$^3$) was used to measure performance on realistic biological meshes.
-All measurements were performed on a single core of an Apple~M4 processor (macOS~15.7.3, Python~3.11).
+All measurements were performed on a single core of an Apple~M4 processor (macOS~15.7.3, Python~3.11, pykarambola~v0.4.0).
 
 On icospheres, the Cython-accelerated build reduced compute time by ~1.5–1.9$\times$ relative to the pure-Python build (Figure~\ref{fig:runtime}).
 The absolute time saved by Cython, grows with mesh size --- from $\sim$0.03~s at subdivision~5 to $\sim$27~s at subdivision~10. 
@@ -208,7 +208,7 @@ We invite the bioimage analysis community to adopt pykarambola as a drop-in morp
 %% -------------------------------------------------------
 pykarambola is released under the GNU General Public License v3.0 or later (GPL-3.0-or-later) and is freely available at \url{https://github.com/Ishihara-SynthMorph/pykarambola}.
 The package can be installed via the Python Package Index (PyPI) with \texttt{pip install pykarambola}.
-A permanent archived version is deposited on Zenodo at \url{https://doi.org/10.5281/zenodo.20127022}.
+Version 0.4.0, the version described in this paper, is permanently archived on Zenodo at \url{https://doi.org/10.5281/zenodo.20127022}.
 Core dependencies are NumPy and SciPy; optional dependencies include Cython (for acceleration) and scikit-image (for label-image API).
 
 %% -------------------------------------------------------

--- a/paper/manuscript.tex
+++ b/paper/manuscript.tex
@@ -154,7 +154,7 @@ The residual discrepancies observed in non-near-zero features arise from differe
 \end{figure}
 
 \subsection*{Label-image API walkthrough}
-To demonstrate the label-image API, we applied \texttt{minkowski\_tensors\_from\_label\_image} to a publicly available 3D fluorescence segmentation of a human induced pluripotent stem cell (hiPSC) in early anaphase/telophase from the Allen Cell Collection~\cite{Viana2020}.
+To demonstrate the label-image API, we applied \texttt{minkowski\_tensors\_from\_label\_image} to a publicly available 3D fluorescence segmentation of a human induced pluripotent stem cell (hiPSC) in early anaphase/telophase from the Allen Cell Collection~\cite{viana2023integrated}.
 The segmentation provides a two-channel binary mask at isotropic voxel spacing of 0.108~$\mu$m: one channel for the DNA (nucleus) and one for the cell body.
 
 Figure~\ref{fig:labelimage} illustrates how the choice of labelling scheme directly determines what the tensors measure, using the DNA channel as a concrete example.

--- a/paper/manuscript.tex
+++ b/paper/manuscript.tex
@@ -206,9 +206,17 @@ We invite the bioimage analysis community to adopt pykarambola as a drop-in morp
 %% -------------------------------------------------------
 \section*{Software availability}
 %% -------------------------------------------------------
-pykarambola is available at \url{https://github.com/Ishihara-SynthMorph/pykarambola}.
+pykarambola is released under the GNU General Public License v3.0 or later (GPL-3.0-or-later) and is freely available at \url{https://github.com/Ishihara-SynthMorph/pykarambola}.
+The package can be installed via the Python Package Index (PyPI) with \texttt{pip install pykarambola}.
+A permanent archived version is deposited on Zenodo at \url{https://doi.org/10.5281/zenodo.20127022}.
 Core dependencies are NumPy and SciPy; optional dependencies include Cython (for acceleration) and scikit-image (for label-image API).
-% TODO (issue #36): Complete software availability statement
+
+%% -------------------------------------------------------
+\section*{Data availability}
+%% -------------------------------------------------------
+All datasets used in this study are publicly available.
+The AdrenalMNIST3D benchmark meshes are part of MedMNIST~\cite{Yang2023MedMNIST} and can be downloaded via the \texttt{medmnist} Python package.
+The Allen Cell Collection segmentations are publicly available through the Allen Institute for Cell Science~\cite{viana2023integrated}.
 
 
 \begin{acknowledgements}

--- a/paper/references.bib
+++ b/paper/references.bib
@@ -1,10 +1,3 @@
-@article{Viana2020,
-    title = {Integrated intracellular organization and its variations in human iPS cells},
-    author = {Viana, Matheus P and Chen, Jianxu and Knijnenburg, Theo A and others},
-    journal = {bioRxiv},
-    year = {2020},
-    doi = {10.1101/2020.12.08.415562},
-}
 
 @article{Stringer2021cellpose,
     title = {Cellpose: a generalist algorithm for cellular segmentation},


### PR DESCRIPTION
## Summary

- Expands the software availability section with PyPI install command, Zenodo DOI (v0.4.0), and explicit license (GPL-3.0-or-later)
- Adds a new data availability section citing AdrenalMNIST3D (Yang et al. 2023) and Allen Cell Collection (Viana et al. 2023)
- Adds pykarambola v0.4.0 to the benchmark environment spec in Methods
- States v0.4.0 explicitly in the Zenodo archive sentence

Blocked-by issues (#10, #11) are both closed, so this is unblocked.

## Test plan
- [ ] Verify manuscript compiles without LaTeX errors
- [ ] Confirm Zenodo DOI resolves: https://doi.org/10.5281/zenodo.20127022
- [ ] Confirm GitHub URL resolves: https://github.com/Ishihara-SynthMorph/pykarambola

🤖 Generated with [Claude Code](https://claude.com/claude-code)