### PR TITLE
paper: add AI tools disclosure to Acknowledgements (closes #127)

### DIFF
--- a/paper/manuscript.tex
+++ b/paper/manuscript.tex
@@ -83,7 +83,7 @@ The API for computing Minkowski tensors directly from segmented 3D label images 
 Pykarambola retains support for the two mesh formats accepted by C++ karambola: the karambola-native \texttt{.poly} format and the Object File Format (\texttt{.off}).
 Three additional parsers for Wavefront OBJ (\texttt{.obj}), binary glTF (\texttt{.glb}), and STereoLithography (\texttt{.stl}) were added to broaden compatibility with mesh files produced by common 3D reconstruction and visualisation tools.
 
-The Python port and software development were assisted by Claude (Opus 4.5 and Sonnet 4.6; Anthropic).
+The Python port and software development were assisted by AI language models (see Acknowledgements for disclosure).
 Numerical correctness of the port was validated by extensive benchmarking against the C++ karambola binary across a diverse set of test meshes, confirming agreement to floating-point precision for all Minkowski scalars, vectors, and tensors.
 
 \subsection*{Acceleration strategy: NumPy vectorization and Cython}
@@ -222,6 +222,10 @@ The Allen Cell Collection segmentations are publicly available through the Allen
 \begin{acknowledgements}
 pykarambola is a GPL\,3.0 derivative work of karambola, the C++ reference implementation by Schaller, Kapfer, and Schröder-Turk~\cite{Schaller2020karambola}.
 This work was supported in part by an American Heart Association Career Development Award (grant 25CDA1432232) to K.I.
+
+\textbf{AI tools disclosure.}
+Claude Opus 4.5 and Claude Sonnet 4.6 (Anthropic) were used during this project for software and code development (Python port, refactoring, and test scaffolding) and for manuscript drafting and editing.
+All AI-assisted outputs were reviewed, edited, and validated by the human authors before inclusion.
 \end{acknowledgements}
 
 \begin{contributions}


### PR DESCRIPTION
## Summary
- Adds a dedicated **AI tools disclosure** paragraph to the Acknowledgements section, naming Claude Opus 4.5 and Claude Sonnet 4.6 (Anthropic), covering both software/code development and manuscript drafting, with an explicit human oversight statement
- Shortens the existing Methods line to a cross-reference pointing to Acknowledgements (avoids duplicate detail)

## Motivation
JOSS requires AI disclosure in Acknowledgements; undisclosed use risks desk rejection. OUP (Bioinformatics Advances) requires a standalone statement covering tool names, versions, purpose, and human oversight confirmation.

## Test plan
- [ ] Verify the manuscript compiles without LaTeX errors
- [ ] Confirm the disclosure paragraph appears in the rendered Acknowledgements section
- [ ] Confirm the Methods cross-reference reads naturally in context

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)