### PR TITLE
fix: move 0.4.0 changelog entries out of Unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Version numbers follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+---
+
+## [0.4.0] - 2026-05-11
+
 ### Added
 - `parse_stl_file()`: load ASCII and binary STL files directly into a `Triangulation`, enabling `minkowski_tensors()` to accept STL meshes without manual parsing. Vertex deduplication is performed automatically. Requires the optional `numpy-stl` extra (`pip install "pykarambola[stl]"`). (#119)
 
@@ -89,7 +93,8 @@ Initial Python port of [karambola](https://github.com/morphometry/karambola).
 
 ---
 
-[Unreleased]: https://github.com/Ishihara-SynthMorph/pykarambola/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/Ishihara-SynthMorph/pykarambola/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/Ishihara-SynthMorph/pykarambola/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/Ishihara-SynthMorph/pykarambola/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/Ishihara-SynthMorph/pykarambola/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/Ishihara-SynthMorph/pykarambola/releases/tag/v0.1.0


### PR DESCRIPTION
## Summary
- Moves the `parse_stl_file()` entry (#119) from `[Unreleased]` into the `[0.4.0] - 2026-05-11` section where it belongs
- Updates the comparison links at the bottom accordingly

## Notes
Changelog-only fix; no code changes. The 0.4.0 release was tagged but the entries were never moved out of `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)