### PR TITLE
feat: add w104_eigvals output (closes #130) — version 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Version numbers follow [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.5.0] - 2026-05-27
+
+### Added
+- `w104_eigvals`: the 6 eigenvalues of the W₁⁰⁴ rank-4 tensor's 6×6 Voigt matrix (computed via `np.linalg.eigh`), added to the `minkowski_tensors` output dict alongside `w104`. Directly comparable to karambola's `w104_eigval` file output. (#130)
+
+---
+
 ## [0.4.0] - 2026-05-11
 
 ### Added

--- a/pykarambola/api.py
+++ b/pykarambola/api.py
@@ -561,6 +561,8 @@ def minkowski_tensors(verts: Union[np.ndarray, Triangulation], faces=None, label
                 out['msm_wl'] = np.array(sph.wl)
             else:
                 out[name] = _extract_result(raw[label])
+                if name == 'w104':
+                    out['w104_eigvals'] = np.linalg.eigh(out['w104'])[0]
 
         # Add eigensystems
         for name in _RANK2:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pykarambola"
-version = "0.4.0"
+version = "0.5.0"
 description = "Python implementation of Karambola – Minkowski tensor morphometry of 3D structures"
 readme = "README.md"
 license = {file = "LICENSE"}


### PR DESCRIPTION
Closes #130

## Summary

- **`w104_eigvals`** added to `minkowski_tensors` output: 6 eigenvalues of the W₁⁰⁴ rank-4 tensor's 6×6 Voigt matrix, computed via `np.linalg.eigh(w104)[0]`
- Directly comparable to karambola's `w104_eigval` file (eigenvalues only, by karambola design)
- Version bumped `0.4.0` → `0.5.0` (API addition)

## Changes

| File | Change |
|------|--------|
| `pykarambola/api.py` | +2 lines: compute and store `w104_eigvals` when `w104` is in output |
| `pyproject.toml` | `0.4.0` → `0.5.0` |
| `CHANGELOG.md` | `[0.5.0]` entry |

## Context

Isolated from PR #131 per reviewer request — the benchmark PR can reference pykarambola 0.5.0 once this merges and is released on PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)