### PR TITLE
Manuscript smallfixes

### DIFF
--- a/paper/manuscript.tex
+++ b/paper/manuscript.tex
@@ -128,7 +128,7 @@ The \texttt{autolabel=True} flag treats the array as a binary mask and delegates
 
 \begin{figure*}
 \centering
-\includegraphics[width=0.95\textwidth]{../assets/pipeline_figure18.png}
+\includegraphics[width=0.92\textwidth]{../assets/pipeline_figure18.png}
 \caption{%
   Computation pipeline of pykarambola.
   Three entry paths converge at the shared core (\texttt{minkowski\_tensors}):

--- a/paper/manuscript.tex
+++ b/paper/manuscript.tex
@@ -280,9 +280,9 @@ Systematic descriptors of three-dimensional shape have been absent from the bioi
 %% -------------------------------------------------------
 \section*{Software availability}
 %% -------------------------------------------------------
-pykarambola is released under the BSD 3-Clause License (BSD-3-Clause) and is freely available at \url{https://github.com/Ishihara-SynthMorph/pykarambola}.
+pykarambola is released under the BSD 3-Clause License and is freely available at \url{https://github.com/Ishihara-SynthMorph/pykarambola}.
 The package can be installed via the Python Package Index (PyPI) with \texttt{pip install pykarambola}.
-Version 0.5.0, the version described in this paper, is permanently archived on Zenodo at \url{https://doi.org/10.5281/zenodo.20418801}.
+Version 0.5.0, the version described in this paper, is archived on Zenodo at \url{https://doi.org/10.5281/zenodo.20418801}.
 Core dependencies are NumPy and SciPy; optional dependencies include Cython (for acceleration) and scikit-image (for label-image API).
 
 %% -------------------------------------------------------

--- a/paper/references.bib
+++ b/paper/references.bib
@@ -45,7 +45,8 @@
     author = {Schaller, Fabian M and Kapfer, Sebastian C and Schr\"{o}der-Turk, Gerd E},
     year = {2020},
     version = {2.0},
-    url = {https://github.com/morphometry/karambola}
+    howpublished = {\url{https://github.com/morphometry/karambola}},
+    url          = {https://github.com/morphometry/karambola}
 }
 
 @article{vanderwalt2014scikit,
@@ -109,7 +110,9 @@
     year      = {2025},
     eprint    = {2502.00092},
     archivePrefix = {arXiv},
-    primaryClass  = {math.ST}
+    primaryClass  = {math.ST},
+    note      = {arXiv:2502.00092},
+    doi       = {10.48550/arXiv.2502.00092}
 }
 
 @incollection{Svane2017,
@@ -148,7 +151,7 @@
 
 @article{Yang2023MedMNIST,
     author    = {Yang, Jiancheng and Shi, Rui and Wei, Donglai and Liu, Zequan and Zhao, Lin and Ke, Bilian and Pfister, Hanspeter and Ni, Bingbing},
-    title     = {{MedMNIST} v2 --- A Large-Scale Lightweight Benchmark for 2{D} and 3{D} Biomedical Image Classification},
+    title     = {{MedMNIST} v2 - A Large-Scale Lightweight Benchmark for 2{D} and 3{D} Biomedical Image Classification},
     journal   = {Scientific Data},
     year      = {2023},
     volume    = {10},


### PR DESCRIPTION
- fix citations
- make fig1 smaller so fig1 legend does not go over margin