### PR TITLE
docs: replace Zenodo citation with bioRxiv preprint (#144)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -6,7 +6,7 @@ date-released: 2026-06-14
 repository-code: "https://github.com/Ishihara-SynthMorph/pykarambola"
 identifiers:
   - type: doi
-    value: "10.5281/zenodo.20418801"
+    value: "10.5281/zenodo.19935285"
 license: BSD-3-Clause
 authors:
   - family-names: "Ishihara"
@@ -16,6 +16,17 @@ authors:
     given-names: "Yajushi"
     orcid: "https://orcid.org/0009-0001-9064-8008"
 references:
+  - type: preprint
+    title: "pykarambola: Minkowski tensor morphometry of 3D structures"
+    doi: "10.64898/2026.06.16.730752"
+    date-published: "2026-06-18"
+    authors:
+      - family-names: "Khurana"
+        given-names: "Yajushi"
+        orcid: "https://orcid.org/0009-0001-9064-8008"
+      - family-names: "Ishihara"
+        given-names: "Keisuke"
+        orcid: "https://orcid.org/0000-0002-8481-8680"
   - type: software
     title: "karambola - 3D Minkowski Tensor Package"
     version: 2.0

--- a/README.md
+++ b/README.md
@@ -280,9 +280,10 @@ Once you have a mesh, pass its vertex and face arrays to `minkowski_tensors(vert
 
 If you use pykarambola in your work, please cite pykarambola and Schröder-Turk group's publication on Minkowski tensors:
 
-> Ishihara, K., & Khurana, Y.
-> *pykarambola: Minkowski tensor morphometry of 3D structures* (v0.5.0).
-> https://doi.org/10.5281/zenodo.20418801
+> Khurana, Y., & Ishihara, K.
+> *pykarambola: Minkowski tensor morphometry of 3D structures.*
+> bioRxiv (2026).
+> https://doi.org/10.64898/2026.06.16.730752
 
 > Schröder-Turk, G. E., Mickel, W., Kapfer, S. C., Schaller, F. M., Breidenbach, B., Hug, D., & Mecke, K.
 > *Minkowski tensors of anisotropic spatial structure.*


### PR DESCRIPTION
Closes #144.

Replaces the Zenodo software citation with the bioRxiv preprint now that it is live.

- DOI: https://doi.org/10.64898/2026.06.16.730752
- Author order follows the preprint (Khurana & Ishihara)