### PR TITLE
docs: add MSM section to minkowski_tensors.md (closes #145)

### DIFF
--- a/docs/minkowski_tensors.md
+++ b/docs/minkowski_tensors.md
@@ -283,8 +283,8 @@ $$Q_{\ell m} = \frac{D_{\ell m}}{A\sqrt{\dfrac{4\pi}{2\ell+1}}}$$
 
 | | |
 |---|---|
-| **pykarambola key** | `msm_ql` (array shape `(12,)`, index $= \ell$, $\ell = 0,\ldots,8$) |
-| **Interpretation** | Strength of $\ell$-fold orientational order of surface normals. $q_0 = 1$ always; $q_\ell \approx 0$ for a smooth sphere; icosahedral symmetry yields a distinctive peak at $\ell = 6$. MSM $q_\ell$ and $w_\ell$ outperform the plain Steinhardt bond-order parameters for characterising disordered particulate matter (Mickel et al. 2013). |
+| **pykarambola key** | `msm_ql` (array shape `(12,)`, index $= \ell$, $\ell = 0,\ldots,8$; indices 9–11 are always zero padding) |
+| **Interpretation** | Strength of $\ell$-fold orientational order of surface normals. $q_0 = 1$ always; $q_\ell \approx 0$ for a smooth sphere; icosahedral symmetry yields a distinctive peak at $\ell = 6$. The series stops at $\ell = 8$ (`MAX_L = 8` in `spherical.py`), matching the default of the karambola C++ reference implementation. MSM $q_\ell$ and $w_\ell$ outperform the plain Steinhardt bond-order parameters for characterising disordered particulate matter (Mickel et al. 2013). |
 
 Analytical definition:
 
@@ -313,7 +313,7 @@ where the parenthesised quantity is the Wigner 3j symbol evaluated via the Racah
 
 | | |
 |---|---|
-| **pykarambola key** | `msm_wl` (array shape `(12,)`, index $= \ell$, $\ell = 0,\ldots,8$) |
+| **pykarambola key** | `msm_wl` (array shape `(12,)`, index $= \ell$, $\ell = 0,\ldots,8$; indices 9–11 are always zero padding) |
 | **Interpretation** | Phase structure of $\ell$-fold orientational order. $w_\ell = 0$ exactly for all odd $\ell$ (parity rule below). Distinguishes crystal symmetries that share the same $q_\ell$ value. |
 
 Analytical definition:
@@ -321,6 +321,12 @@ Analytical definition:
 $$
 w_\ell = \sqrt{\frac{4\pi}{2\ell+1}}\cdot\text{sgn}(\tilde{w}_\ell)\cdot|\tilde{w}_\ell|^{1/3}
 $$
+
+> **Convention note.** pykarambola's $w_\ell$ is the *unnormalized* cube-root form above and is
+> **not** divided by $q_\ell^3$. The Steinhardt (1983) and Mickel et al. (2013) convention is
+> $w_\ell^{\text{std}} = \tilde{w}_\ell / \bigl(\sum_m |Q_{\ell m}|^2\bigr)^{3/2}$.
+> These two quantities differ by a factor of $q_\ell^3$; numerical values will not match the
+> FCC/BCC tables in either paper when using pykarambola's output directly.
 
 Computational form: let
 
@@ -336,6 +342,9 @@ $$
 \mathtt{msm\_wl}[\ell] = \text{sgn}(\text{Re}(v))\cdot|v|^{1/3}/A
 $$
 
+($v$ is real for any closed mesh — imaginary parts cancel by the conjugation symmetry
+$D_{\ell,-m} = (-1)^m\,\overline{D_{\ell m}}$ — so $\operatorname{sgn}(\operatorname{Re}(v)) = \operatorname{sgn}(v)$.)
+
 **Parity selection rule.** For odd $\ell$, the Wigner 3j symbol above is antisymmetric
 under exchange of any two columns (each exchange contributes $(-1)^{3\ell}=-1$),
 while $Q_{\ell m_1}Q_{\ell m_2}Q_{\ell m_3}$ is symmetric.
@@ -343,21 +352,25 @@ Every term in $\tilde{w}_\ell$ therefore cancels exactly with its column-swapped
 
 $$w_\ell = 0 \quad \text{exactly for all odd } \ell$$
 
-pykarambola enforces this analytically via the `J % 2 != 0` branch of the Racah formula.
-The C++ karambola accumulates small spurious residuals for odd $\ell$ due to floating-point
-rounding in its separate code path.
+The internal `_wigner3j` helper uses a `J % 2 != 0` early-return as a performance shortcut;
+this shortcut gives the correct result for `msm_wl` (where the full sum cancels by the
+antisymmetry argument above) but is **not** a general Wigner 3j selection rule and returns
+incorrect values for callers with odd $j_1+j_2+j_3$ outside this context — see
+[#137](https://github.com/Ishihara-SynthMorph/pykarambola/issues/137) for the known
+limitation. The C++ karambola accumulates small spurious residuals for odd $\ell$ due to
+floating-point rounding in its separate code path.
 
 **Connection to Cartesian moment tensors.**
 The MSM $q_\ell$, $w_\ell$ and the Cartesian moment tensors $W_1^{0,\ell}$ are different
-representations of the same Minkowski tensors and can therefore be related to each other
-(Mickel et al. 2013):
+representations of the same Minkowski tensors and are therefore mathematically related
+(Mickel et al. 2013). However, in pykarambola this relationship is **not** used
+computationally: `msm_ql` and `msm_wl` are computed via a separate spherical harmonic
+accumulation in `spherical.py` that reads face normals directly and shares no code with
+the `w104` computation path. The formula below is provided for cross-checking only:
 
 $$
-W_1^{0,\ell} = \sum_{f \in F} \underbrace{\hat{n}_f \otimes \cdots \otimes \hat{n}_f}_{\ell \text{ times}} A_f
+W_1^{0,\ell} = \frac{1}{3}\sum_{f \in F} \underbrace{\hat{n}_f \otimes \cdots \otimes \hat{n}_f}_{\ell \text{ times}} A_f
 $$
-
-In pykarambola, all MSM are computed via an independent spherical harmonic accumulation
-directly from face normals (see `spherical.py`), not derived from any $W_1^{0,\ell}$.
 
 ---
 
@@ -393,10 +406,6 @@ For every rank-2 tensor $W$ above, pykarambola additionally computes:
   [doi:10.1063/1.4774084](https://doi.org/10.1063/1.4774084)
 - Schröder-Turk, G. E. et al. *Minkowski Tensors of Anisotropic Spatial Structure.*
   New J. Phys. **15**, 083028 (2013). [doi:10.1088/1367-2630/15/8/083028](https://doi.org/10.1088/1367-2630/15/8/083028)
-- Mickel, W., Kapfer, S. C., Schröder-Turk, G. E., & Mecke, K. (2013).
-  Shortcomings of the bond orientational order parameters for the analysis of disordered particulate matter.
-  *J. Chem. Phys.*, **138**(4), 044501.
-  [doi:10.1063/1.4774084](https://doi.org/10.1063/1.4774084)
 - Schaller, F. M., Kapfer, S. C., & Schröder-Turk, G. E.
   *karambola — 3D Minkowski Tensor Package* (v2.0).
   <https://github.com/morphometry/karambola>

--- a/docs/minkowski_tensors.md
+++ b/docs/minkowski_tensors.md
@@ -264,8 +264,9 @@ $\ell$-fold orientational order of surface normals (Steinhardt, Nelson & Ronchet
 Mickel et al. 2013; Schröder-Turk et al. 2013). Both are computed from area-weighted spherical harmonic
 moments of face normals for $\ell = 0, \ldots, 8$ and returned only with `compute='all'`.
 
-**Shared intermediate accumulation.** Let $(\theta_f, \phi_f)$ be the polar and azimuthal
-angles of $\hat{n}_f$, and let $A = \sum_f A_f = 3\,w_{100}$.
+**Shared intermediate accumulation.**
+Let $(\theta_f, \phi_f)$ be the polar and azimuthal angles of face normal $\hat{n}_{f}$,
+and let $A = \sum_{f} A_{f} = 3 w_{100}$ be the total surface area.
 For each $\ell$ and $m = 0, 1, \ldots, \ell$, the code accumulates:
 
 $$D_{\ell m} = \sqrt{\frac{4\pi}{2\ell+1}}\sum_f A_f\, Y_\ell^m(\theta_f,\,\phi_f)$$
@@ -292,7 +293,7 @@ $$
 Computational form (exploits $|D_{\ell,-m}| = |D_{\ell m}|$):
 
 $$
-\text{msm\_ql}[\ell] = \frac{1}{A}\sqrt{|D_{\ell 0}|^2 + 2\sum_{m=1}^{\ell}|D_{\ell m}|^2}
+\mathtt{msm\_ql}[\ell] = \frac{1}{A}\sqrt{|D_{\ell 0}|^2 + 2\sum_{m=1}^{\ell}|D_{\ell m}|^2}
 $$
 
 #### msm_wl — $w_\ell$
@@ -306,13 +307,7 @@ $$
 Q_{\ell m_1}\,Q_{\ell m_2}\,Q_{\ell m_3}
 $$
 
-where
-
-$$
-\begin{pmatrix}\ell & \ell & \ell \\ m_1 & m_2 & m_3\end{pmatrix}
-$$
-
-is the Wigner 3j symbol evaluated via the Racah formula.
+where the parenthesised quantity is the Wigner 3j symbol evaluated via the Racah formula.
 
 | | |
 |---|---|
@@ -333,7 +328,11 @@ v = \sum_{m_1+m_2+m_3=0}
 D_{\ell m_1}\,D_{\ell m_2}\,D_{\ell m_3}
 $$
 
-then $\text{msm\_wl}[\ell] = \text{sgn}(\text{Re}(v))\cdot|v|^{1/3}/A$.
+then:
+
+$$
+\mathtt{msm\_wl}[\ell] = \text{sgn}(\text{Re}(v))\cdot|v|^{1/3}/A
+$$
 
 **Parity selection rule.** The Wigner 3j symbol vanishes for all $m_1, m_2, m_3$
 whenever $J = 3\ell$ is odd (i.e., $\ell$ odd), so:

--- a/docs/minkowski_tensors.md
+++ b/docs/minkowski_tensors.md
@@ -257,6 +257,68 @@ w_{104} = \frac{1}{3}\sum_f A_f\, \mathbf{t}_f \mathbf{t}_f^\top, \qquad
 \mathbf{t}_f = \bigl[n_x^2,\; n_y^2,\; n_z^2,\; \sqrt{2}\,n_yn_z,\; \sqrt{2}\,n_xn_z,\; \sqrt{2}\,n_xn_y\bigr]^\top
 $$
 
+### msm_ql, msm_wl — Minkowski Structure Metrics
+
+The Minkowski Structure Metrics (MSM) are rotationally invariant scalars that quantify
+$\ell$-fold orientational order of surface normals (Steinhardt, Nelson & Ronchetti 1983;
+Schröder-Turk et al. 2013). Both are computed from area-weighted spherical harmonic
+moments of face normals for $\ell = 0, \ldots, 8$ and returned only with `compute='all'`.
+
+**Shared intermediate accumulation.** Let $(\theta_f, \phi_f)$ be the polar and azimuthal
+angles of $\hat{n}_f$, and let $A = \sum_f A_f = 3\,w_{100}$.
+For each $\ell$ and $m = 0, 1, \ldots, \ell$, the code accumulates:
+
+$$D_{\ell m} = \sqrt{\frac{4\pi}{2\ell+1}}\sum_f A_f\, Y_\ell^m(\theta_f,\,\phi_f)$$
+
+where $Y_\ell^m$ are complex spherical harmonics in the Condon–Shortley convention.
+Only $m \ge 0$ is stored; negative-$m$ values are recovered via
+$D_{\ell,-m} = (-1)^m\,\overline{D_{\ell m}}$ (exact for the real-valued normal
+distribution of a closed mesh).
+The area-normalised moments are $Q_{\ell m} = D_{\ell m}\big/\!\bigl(A\sqrt{4\pi/(2\ell+1)}\bigr)$.
+
+#### msm_ql — $q_\ell$
+
+| | |
+|---|---|
+| **pykarambola key** | `msm_ql` (array shape `(12,)`, index $= \ell$, $\ell = 0,\ldots,8$) |
+| **Analytical** | $q_\ell = \sqrt{\dfrac{4\pi}{2\ell+1}\displaystyle\sum_{m=-\ell}^{\ell}\lvert Q_{\ell m}\rvert^2}$ |
+| **Computational** | $\text{msm\_ql}[\ell] = \dfrac{1}{A}\sqrt{\lvert D_{\ell 0}\rvert^2 + 2\displaystyle\sum_{m=1}^{\ell}\lvert D_{\ell m}\rvert^2}$ (exploits $\lvert D_{\ell,-m}\rvert = \lvert D_{\ell m}\rvert$) |
+| **Interpretation** | Strength of $\ell$-fold orientational order of surface normals. $q_0 = 1$ always; $q_\ell \approx 0$ for a smooth sphere; icosahedral symmetry yields a distinctive peak at $\ell = 6$. |
+
+#### msm_wl — $w_\ell$
+
+Define the third-order invariant before cube-root normalisation, where the sum runs over all
+$(m_1, m_2, m_3)$ with $m_i \in \{-\ell,\ldots,\ell\}$ and $m_1+m_2+m_3 = 0$:
+
+$$\tilde{w}_\ell = \sum_{\substack{m_1,m_2,m_3 \,\in\, [-\ell,\ell] \\ m_1+m_2+m_3=0}}
+\begin{pmatrix}\ell & \ell & \ell \\ m_1 & m_2 & m_3\end{pmatrix}
+Q_{\ell m_1}\,Q_{\ell m_2}\,Q_{\ell m_3}$$
+
+where $\bigl(\begin{smallmatrix}\ell & \ell & \ell \\ m_1 & m_2 & m_3\end{smallmatrix}\bigr)$
+is the Wigner 3j symbol evaluated via the Racah formula.
+
+| | |
+|---|---|
+| **pykarambola key** | `msm_wl` (array shape `(12,)`, index $= \ell$, $\ell = 0,\ldots,8$) |
+| **Analytical** | $w_\ell = \sqrt{\dfrac{4\pi}{2\ell+1}}\cdot\text{sgn}(\tilde{w}_\ell)\cdot\lvert\tilde{w}_\ell\rvert^{1/3}$ |
+| **Computational** | Let $v = \displaystyle\sum_{m_1+m_2+m_3=0}\bigl(\begin{smallmatrix}\ell\;\ell\;\ell\\m_1\,m_2\,m_3\end{smallmatrix}\bigr) D_{\ell m_1} D_{\ell m_2} D_{\ell m_3}$; then $\text{msm\_wl}[\ell] = \text{sgn}(\text{Re}(v))\cdot\lvert v\rvert^{1/3}/A$ |
+| **Interpretation** | Phase structure of $\ell$-fold orientational order. $w_\ell = 0$ exactly for all odd $\ell$ (parity rule below). Distinguishes crystal symmetries that share the same $q_\ell$ value. |
+
+**Parity selection rule.** The Wigner 3j symbol
+$\bigl(\begin{smallmatrix}\ell & \ell & \ell \\ m_1 & m_2 & m_3\end{smallmatrix}\bigr)$
+vanishes for all $m_1, m_2, m_3$ whenever $J = 3\ell$ is odd (i.e., $\ell$ odd), so:
+
+$$w_\ell = 0 \quad \text{exactly for all odd } \ell$$
+
+pykarambola enforces this analytically via the `J % 2 != 0` branch of the Racah formula.
+The C++ karambola accumulates small spurious residuals for odd $\ell$ due to floating-point
+rounding in its separate code path.
+
+**Connection to w104.** The rank-4 normal tensor `w104` ($W_1^{0,4}$) encodes the
+$\ell = 0, 2, 4$ irreducible SO(3) components of the normal distribution, so $q_4$ and $w_4$
+are implicitly contained in it. The $\ell = 6, 8$ MSM require spherical harmonic evaluation
+beyond what `w104` encodes and are computed independently from face normals.
+
 ---
 
 ## Derived scalars (`compute='all'`)
@@ -280,6 +342,10 @@ For every rank-2 tensor $W$ above, pykarambola additionally computes:
 
 ## References
 
+- Steinhardt, P. J., Nelson, D. R., & Ronchetti, M. (1983).
+  Bond-orientational order in liquids and glasses.
+  *Phys. Rev. B*, **28**(2), 784–805.
+  [doi:10.1103/PhysRevB.28.784](https://doi.org/10.1103/PhysRevB.28.784)
 - Schröder-Turk, G. E. et al. *Minkowski Tensors of Anisotropic Spatial Structure.*
   New J. Phys. **15**, 083028 (2013). [doi:10.1088/1367-2630/15/8/083028](https://doi.org/10.1088/1367-2630/15/8/083028)
 - Schaller, F. M., Kapfer, S. C., & Schröder-Turk, G. E.

--- a/docs/minkowski_tensors.md
+++ b/docs/minkowski_tensors.md
@@ -283,7 +283,7 @@ The area-normalised moments are $Q_{\ell m} = D_{\ell m}\big/\!\bigl(A\sqrt{4\pi
 | **pykarambola key** | `msm_ql` (array shape `(12,)`, index $= \ell$, $\ell = 0,\ldots,8$) |
 | **Analytical** | $q_\ell = \sqrt{\dfrac{4\pi}{2\ell+1}\displaystyle\sum_{m=-\ell}^{\ell}\lvert Q_{\ell m}\rvert^2}$ |
 | **Computational** | $\text{msm\_ql}[\ell] = \dfrac{1}{A}\sqrt{\lvert D_{\ell 0}\rvert^2 + 2\displaystyle\sum_{m=1}^{\ell}\lvert D_{\ell m}\rvert^2}$ (exploits $\lvert D_{\ell,-m}\rvert = \lvert D_{\ell m}\rvert$) |
-| **Interpretation** | Strength of $\ell$-fold orientational order of surface normals. $q_0 = 1$ always; $q_\ell \approx 0$ for a smooth sphere; icosahedral symmetry yields a distinctive peak at $\ell = 6$. |
+| **Interpretation** | Strength of $\ell$-fold orientational order of surface normals. $q_0 = 1$ always; $q_\ell \approx 0$ for a smooth sphere; icosahedral symmetry yields a distinctive peak at $\ell = 6$. MSM $q_\ell$ and $w_\ell$ outperform the plain Steinhardt bond-order parameters for characterising disordered particulate matter (Mickel et al. 2013). |
 
 #### msm_wl — $w_\ell$
 
@@ -348,6 +348,10 @@ For every rank-2 tensor $W$ above, pykarambola additionally computes:
   [doi:10.1103/PhysRevB.28.784](https://doi.org/10.1103/PhysRevB.28.784)
 - Schröder-Turk, G. E. et al. *Minkowski Tensors of Anisotropic Spatial Structure.*
   New J. Phys. **15**, 083028 (2013). [doi:10.1088/1367-2630/15/8/083028](https://doi.org/10.1088/1367-2630/15/8/083028)
+- Mickel, W., Kapfer, S. C., Schröder-Turk, G. E., & Mecke, K. (2013).
+  Shortcomings of the bond orientational order parameters for the analysis of disordered particulate matter.
+  *J. Chem. Phys.*, **138**(4), 044501.
+  [doi:10.1063/1.4774084](https://doi.org/10.1063/1.4774084)
 - Schaller, F. M., Kapfer, S. C., & Schröder-Turk, G. E.
   *karambola — 3D Minkowski Tensor Package* (v2.0).
   <https://github.com/morphometry/karambola>

--- a/docs/minkowski_tensors.md
+++ b/docs/minkowski_tensors.md
@@ -225,7 +225,7 @@ Note: `{key}_trace_ratio` is **not** defined for normal-weighted tensors (no nat
 | **Interpretation** | Curvature-weighted normal distribution; sensitive to both orientation and bending magnitude. `w202_beta` = anisotropy of curvature-weighted normals. |
 
 $$
-w_{202,ij} = \sum_e \left[ \frac{\ell_e(\alpha_e + \sin\alpha_e)}{24}\,\bar{n}_{e,i}\bar{n}_{e,j} + \frac{\ell_e(\alpha_e - \sin\alpha_e)}{24}\,n_{\perp,e,i}\,n_{\perp,e,j} \right]
+w_{202,ij} = \sum_e \left[ \frac{\ell_e(\alpha_e + \sin\alpha_e)}{12}\,\bar{n}_{e,i}\bar{n}_{e,j} + \frac{\ell_e(\alpha_e - \sin\alpha_e)}{12}\,n_{\perp,e,i}\,n_{\perp,e,j} \right]
 $$
 
 The $\alpha \pm \sin\alpha$ split follows from the exact integral of $n \otimes n$ over the cylindrical patch at the edge.
@@ -265,8 +265,8 @@ Mickel et al. 2013; Schröder-Turk et al. 2013). Both are computed from area-wei
 moments of face normals for $\ell = 0, \ldots, 8$ and returned only with `compute='all'`.
 
 **Shared intermediate accumulation.**
-Let $(\theta_f, \phi_f)$ be the polar and azimuthal angles of face normal $\hat{n}_{f}$,
-and let $A = \sum_{f} A_{f} = 3 w_{100}$ be the total surface area.
+Let $(\theta_f, \phi_f)$ be the polar and azimuthal angles of face normal $\hat{n}_f$.
+Let $A = \sum_f A_f = 3 w_{100}$ be the total surface area.
 For each $\ell$ and $m = 0, 1, \ldots, \ell$, the code accumulates:
 
 $$D_{\ell m} = \sqrt{\frac{4\pi}{2\ell+1}}\sum_f A_f\, Y_\ell^m(\theta_f,\,\phi_f)$$
@@ -275,7 +275,9 @@ where $Y_\ell^m$ are complex spherical harmonics in the Condon–Shortley conven
 Only $m \ge 0$ is stored; negative-$m$ values are recovered via
 $D_{\ell,-m} = (-1)^m\,\overline{D_{\ell m}}$ (exact for the real-valued normal
 distribution of a closed mesh).
-The area-normalised moments are $Q_{\ell m} = D_{\ell m}\big/\!\bigl(A\sqrt{4\pi/(2\ell+1)}\bigr)$.
+The area-normalised moments are:
+
+$$Q_{\ell m} = \frac{D_{\ell m}}{A\sqrt{\dfrac{4\pi}{2\ell+1}}}$$
 
 #### msm_ql — $q_\ell$
 
@@ -303,7 +305,7 @@ $(m_1, m_2, m_3)$ with $m_i \in \{-\ell,\ldots,\ell\}$ and $m_1+m_2+m_3 = 0$:
 
 $$
 \tilde{w}_\ell = \sum_{m_1+m_2+m_3=0}
-\begin{pmatrix}\ell & \ell & \ell \\ m_1 & m_2 & m_3\end{pmatrix}
+\left(\begin{array}{ccc}\ell & \ell & \ell \\ m_1 & m_2 & m_3\end{array}\right)
 Q_{\ell m_1}\,Q_{\ell m_2}\,Q_{\ell m_3}
 $$
 
@@ -324,7 +326,7 @@ Computational form: let
 
 $$
 v = \sum_{m_1+m_2+m_3=0}
-\begin{pmatrix}\ell & \ell & \ell \\ m_1 & m_2 & m_3\end{pmatrix}
+\left(\begin{array}{ccc}\ell & \ell & \ell \\ m_1 & m_2 & m_3\end{array}\right)
 D_{\ell m_1}\,D_{\ell m_2}\,D_{\ell m_3}
 $$
 
@@ -334,8 +336,10 @@ $$
 \mathtt{msm\_wl}[\ell] = \text{sgn}(\text{Re}(v))\cdot|v|^{1/3}/A
 $$
 
-**Parity selection rule.** The Wigner 3j symbol vanishes for all $m_1, m_2, m_3$
-whenever $J = 3\ell$ is odd (i.e., $\ell$ odd), so:
+**Parity selection rule.** For odd $\ell$, the Wigner 3j symbol above is antisymmetric
+under exchange of any two columns (each exchange contributes $(-1)^{3\ell}=-1$),
+while $Q_{\ell m_1}Q_{\ell m_2}Q_{\ell m_3}$ is symmetric.
+Every term in $\tilde{w}_\ell$ therefore cancels exactly with its column-swapped partner, so:
 
 $$w_\ell = 0 \quad \text{exactly for all odd } \ell$$
 

--- a/docs/minkowski_tensors.md
+++ b/docs/minkowski_tensors.md
@@ -343,10 +343,17 @@ pykarambola enforces this analytically via the `J % 2 != 0` branch of the Racah 
 The C++ karambola accumulates small spurious residuals for odd $\ell$ due to floating-point
 rounding in its separate code path.
 
-**Connection to w104.** The rank-4 normal tensor `w104` ($W_1^{0,4}$) encodes the
-$\ell = 0, 2, 4$ irreducible SO(3) components of the normal distribution, so $q_4$ and $w_4$
-are implicitly contained in it. The $\ell = 6, 8$ MSM require spherical harmonic evaluation
-beyond what `w104` encodes and are computed independently from face normals.
+**Connection to Cartesian moment tensors.**
+The MSM $q_\ell$, $w_\ell$ and the Cartesian moment tensors $W_1^{0,\ell}$ are different
+representations of the same Minkowski tensors and can therefore be related to each other
+(Mickel et al. 2013):
+
+$$
+W_1^{0,\ell} = \sum_{f \in F} \underbrace{\hat{n}_f \otimes \cdots \otimes \hat{n}_f}_{\ell \text{ times}} A_f
+$$
+
+In pykarambola, all MSM are computed via an independent spherical harmonic accumulation
+directly from face normals (see `spherical.py`), not derived from any $W_1^{0,\ell}$.
 
 ---
 

--- a/docs/minkowski_tensors.md
+++ b/docs/minkowski_tensors.md
@@ -261,7 +261,7 @@ $$
 
 The Minkowski Structure Metrics (MSM) are rotationally invariant scalars that quantify
 $\ell$-fold orientational order of surface normals (Steinhardt, Nelson & Ronchetti 1983;
-Schröder-Turk et al. 2013). Both are computed from area-weighted spherical harmonic
+Mickel et al. 2013; Schröder-Turk et al. 2013). Both are computed from area-weighted spherical harmonic
 moments of face normals for $\ell = 0, \ldots, 8$ and returned only with `compute='all'`.
 
 **Shared intermediate accumulation.** Let $(\theta_f, \phi_f)$ be the polar and azimuthal
@@ -281,32 +281,62 @@ The area-normalised moments are $Q_{\ell m} = D_{\ell m}\big/\!\bigl(A\sqrt{4\pi
 | | |
 |---|---|
 | **pykarambola key** | `msm_ql` (array shape `(12,)`, index $= \ell$, $\ell = 0,\ldots,8$) |
-| **Analytical** | $q_\ell = \sqrt{\dfrac{4\pi}{2\ell+1}\displaystyle\sum_{m=-\ell}^{\ell}\lvert Q_{\ell m}\rvert^2}$ |
-| **Computational** | $\text{msm\_ql}[\ell] = \dfrac{1}{A}\sqrt{\lvert D_{\ell 0}\rvert^2 + 2\displaystyle\sum_{m=1}^{\ell}\lvert D_{\ell m}\rvert^2}$ (exploits $\lvert D_{\ell,-m}\rvert = \lvert D_{\ell m}\rvert$) |
 | **Interpretation** | Strength of $\ell$-fold orientational order of surface normals. $q_0 = 1$ always; $q_\ell \approx 0$ for a smooth sphere; icosahedral symmetry yields a distinctive peak at $\ell = 6$. MSM $q_\ell$ and $w_\ell$ outperform the plain Steinhardt bond-order parameters for characterising disordered particulate matter (Mickel et al. 2013). |
+
+Analytical definition:
+
+$$
+q_\ell = \sqrt{\frac{4\pi}{2\ell+1}\sum_{m=-\ell}^{\ell}|Q_{\ell m}|^2}
+$$
+
+Computational form (exploits $|D_{\ell,-m}| = |D_{\ell m}|$):
+
+$$
+\text{msm\_ql}[\ell] = \frac{1}{A}\sqrt{|D_{\ell 0}|^2 + 2\sum_{m=1}^{\ell}|D_{\ell m}|^2}
+$$
 
 #### msm_wl — $w_\ell$
 
 Define the third-order invariant before cube-root normalisation, where the sum runs over all
 $(m_1, m_2, m_3)$ with $m_i \in \{-\ell,\ldots,\ell\}$ and $m_1+m_2+m_3 = 0$:
 
-$$\tilde{w}_\ell = \sum_{\substack{m_1,m_2,m_3 \,\in\, [-\ell,\ell] \\ m_1+m_2+m_3=0}}
+$$
+\tilde{w}_\ell = \sum_{m_1+m_2+m_3=0}
 \begin{pmatrix}\ell & \ell & \ell \\ m_1 & m_2 & m_3\end{pmatrix}
-Q_{\ell m_1}\,Q_{\ell m_2}\,Q_{\ell m_3}$$
+Q_{\ell m_1}\,Q_{\ell m_2}\,Q_{\ell m_3}
+$$
 
-where $\bigl(\begin{smallmatrix}\ell & \ell & \ell \\ m_1 & m_2 & m_3\end{smallmatrix}\bigr)$
+where
+
+$$
+\begin{pmatrix}\ell & \ell & \ell \\ m_1 & m_2 & m_3\end{pmatrix}
+$$
+
 is the Wigner 3j symbol evaluated via the Racah formula.
 
 | | |
 |---|---|
 | **pykarambola key** | `msm_wl` (array shape `(12,)`, index $= \ell$, $\ell = 0,\ldots,8$) |
-| **Analytical** | $w_\ell = \sqrt{\dfrac{4\pi}{2\ell+1}}\cdot\text{sgn}(\tilde{w}_\ell)\cdot\lvert\tilde{w}_\ell\rvert^{1/3}$ |
-| **Computational** | Let $v = \displaystyle\sum_{m_1+m_2+m_3=0}\bigl(\begin{smallmatrix}\ell\;\ell\;\ell\\m_1\,m_2\,m_3\end{smallmatrix}\bigr) D_{\ell m_1} D_{\ell m_2} D_{\ell m_3}$; then $\text{msm\_wl}[\ell] = \text{sgn}(\text{Re}(v))\cdot\lvert v\rvert^{1/3}/A$ |
 | **Interpretation** | Phase structure of $\ell$-fold orientational order. $w_\ell = 0$ exactly for all odd $\ell$ (parity rule below). Distinguishes crystal symmetries that share the same $q_\ell$ value. |
 
-**Parity selection rule.** The Wigner 3j symbol
-$\bigl(\begin{smallmatrix}\ell & \ell & \ell \\ m_1 & m_2 & m_3\end{smallmatrix}\bigr)$
-vanishes for all $m_1, m_2, m_3$ whenever $J = 3\ell$ is odd (i.e., $\ell$ odd), so:
+Analytical definition:
+
+$$
+w_\ell = \sqrt{\frac{4\pi}{2\ell+1}}\cdot\text{sgn}(\tilde{w}_\ell)\cdot|\tilde{w}_\ell|^{1/3}
+$$
+
+Computational form: let
+
+$$
+v = \sum_{m_1+m_2+m_3=0}
+\begin{pmatrix}\ell & \ell & \ell \\ m_1 & m_2 & m_3\end{pmatrix}
+D_{\ell m_1}\,D_{\ell m_2}\,D_{\ell m_3}
+$$
+
+then $\text{msm\_wl}[\ell] = \text{sgn}(\text{Re}(v))\cdot|v|^{1/3}/A$.
+
+**Parity selection rule.** The Wigner 3j symbol vanishes for all $m_1, m_2, m_3$
+whenever $J = 3\ell$ is odd (i.e., $\ell$ odd), so:
 
 $$w_\ell = 0 \quad \text{exactly for all odd } \ell$$
 
@@ -346,6 +376,11 @@ For every rank-2 tensor $W$ above, pykarambola additionally computes:
   Bond-orientational order in liquids and glasses.
   *Phys. Rev. B*, **28**(2), 784–805.
   [doi:10.1103/PhysRevB.28.784](https://doi.org/10.1103/PhysRevB.28.784)
+- Mickel, W., Kapfer, S. C., Schröder-Turk, G. E., & Mecke, K. (2013).
+  Shortcomings of the bond orientational order parameters for the study of disordered
+  particulate matter.
+  *J. Chem. Phys.*, **138**(4), 044501.
+  [doi:10.1063/1.4774084](https://doi.org/10.1063/1.4774084)
 - Schröder-Turk, G. E. et al. *Minkowski Tensors of Anisotropic Spatial Structure.*
   New J. Phys. **15**, 083028 (2013). [doi:10.1088/1367-2630/15/8/083028](https://doi.org/10.1088/1367-2630/15/8/083028)
 - Mickel, W., Kapfer, S. C., Schröder-Turk, G. E., & Mecke, K. (2013).

--- a/docs/minkowski_tensors.md
+++ b/docs/minkowski_tensors.md
@@ -404,7 +404,7 @@ For every rank-2 tensor $W$ above, pykarambola additionally computes:
   *Phys. Rev. B*, **28**(2), 784–805.
   [doi:10.1103/PhysRevB.28.784](https://doi.org/10.1103/PhysRevB.28.784)
 - Mickel, W., Kapfer, S. C., Schröder-Turk, G. E., & Mecke, K. (2013).
-  Shortcomings of the bond orientational order parameters for the study of disordered
+  Shortcomings of the bond orientational order parameters for the analysis of disordered
   particulate matter.
   *J. Chem. Phys.*, **138**(4), 044501.
   [doi:10.1063/1.4774084](https://doi.org/10.1063/1.4774084)

--- a/docs/minkowski_tensors.md
+++ b/docs/minkowski_tensors.md
@@ -284,7 +284,7 @@ $$Q_{\ell m} = \frac{D_{\ell m}}{A\sqrt{\dfrac{4\pi}{2\ell+1}}}$$
 | | |
 |---|---|
 | **pykarambola key** | `msm_ql` (array shape `(12,)`, index $= \ell$, $\ell = 0,\ldots,8$; indices 9–11 are always zero padding) |
-| **Interpretation** | Strength of $\ell$-fold orientational order of surface normals. $q_0 = 1$ always; $q_\ell \approx 0$ for a smooth sphere; icosahedral symmetry yields a distinctive peak at $\ell = 6$. The series stops at $\ell = 8$ (`MAX_L = 8` in `spherical.py`), matching the default of the karambola C++ reference implementation. MSM $q_\ell$ and $w_\ell$ outperform the plain Steinhardt bond-order parameters for characterising disordered particulate matter (Mickel et al. 2013). |
+| **Interpretation** | Strength of $\ell$-fold orientational order of surface normals. $q_0 = 1$ always; $q_\ell \approx 0$ for a smooth sphere; icosahedral symmetry yields a distinctive peak at $\ell = 6$. The series stops at $\ell = 8$ (`MAX_L = 8` in `spherical.py`), matching the default of the karambola C++ reference implementation. MSM $q_\ell$ outperforms the plain Steinhardt bond-order parameters for characterising disordered particulate matter (Mickel et al. 2013). |
 
 Analytical definition:
 
@@ -322,11 +322,13 @@ $$
 w_\ell = \sqrt{\frac{4\pi}{2\ell+1}}\cdot\text{sgn}(\tilde{w}_\ell)\cdot|\tilde{w}_\ell|^{1/3}
 $$
 
-> **Convention note.** pykarambola's $w_\ell$ is the *unnormalized* cube-root form above and is
-> **not** divided by $q_\ell^3$. The Steinhardt (1983) and Mickel et al. (2013) convention is
+> **Convention note.** pykarambola's $w_\ell$ is the *unnormalized* cube-root form above.
+> The Steinhardt (1983) convention is the normalized form
 > $w_\ell^{\text{std}} = \tilde{w}_\ell / \bigl(\sum_m |Q_{\ell m}|^2\bigr)^{3/2}$.
-> These two quantities differ by a factor of $q_\ell^3$; numerical values will not match the
-> FCC/BCC tables in either paper when using pykarambola's output directly.
+> The two are related by a cubic, not a linear, rescaling:
+> $$w_\ell^{\text{std}} = \left(\frac{w_\ell}{q_\ell}\right)^3$$
+> Numerical values will not match the FCC/BCC tables in Steinhardt (1983) when using
+> pykarambola's output directly.
 
 Computational form: let
 
@@ -361,12 +363,14 @@ limitation. The C++ karambola accumulates small spurious residuals for odd $\ell
 floating-point rounding in its separate code path.
 
 **Connection to Cartesian moment tensors.**
-The MSM $q_\ell$, $w_\ell$ and the Cartesian moment tensors $W_1^{0,\ell}$ are different
+The MSM $q_\ell$ and the Cartesian moment tensors $W_1^{0,\ell}$ are different
 representations of the same Minkowski tensors and are therefore mathematically related
 (Mickel et al. 2013). However, in pykarambola this relationship is **not** used
 computationally: `msm_ql` and `msm_wl` are computed via a separate spherical harmonic
 accumulation in `spherical.py` that reads face normals directly and shares no code with
-the `w104` computation path. The formula below is provided for cross-checking only:
+the `w104` computation path. The formula below is provided for cross-checking only
+(Schröder-Turk et al. 2013 convention with the $\tfrac{1}{3}$ Steiner prefactor; Mickel et al. 2013
+eq. (4) uses the same tensor without this prefactor):
 
 $$
 W_1^{0,\ell} = \frac{1}{3}\sum_{f \in F} \underbrace{\hat{n}_f \otimes \cdots \otimes \hat{n}_f}_{\ell \text{ times}} A_f


### PR DESCRIPTION
## Summary

- Adds a dedicated **Minkowski Structure Metrics** section to `docs/minkowski_tensors.md`, closing #145
- Covers `msm_ql` ($q_\ell$) and `msm_wl` ($w_\ell$) for $\ell = 0, \ldots, 8$
- Documents shared intermediate $D_{\ell m}$ accumulation (area-weighted spherical harmonics)
- Analytical and computational formulas for both metrics
- Parity selection rule: $w_\ell = 0$ exactly for odd $\ell$ (pykarambola Racah vs C++ karambola spurious residuals)
- Array shape note: `(12,)`, entries 0–8 meaningful
- Connection to `w104` and when independent face-normal evaluation is needed
- Adds **Mickel et al. (2013)** citation (J. Chem. Phys. 138, 044501) — the canonical MSM paper introducing Minkowski-tensor-based improvements over Steinhardt bond-order parameters
- Fixes GitHub LaTeX rendering: all heavy formulas moved to `$$` display blocks; `\begin{smallmatrix}` and `\substack` removed from inline/table-cell contexts; `\dfrac`/`\displaystyle` removed from table cells

## References added

- Steinhardt, Nelson & Ronchetti (1983) — original bond-order parameters
- Mickel, Kapfer, Schröder-Turk & Mecke (2013) — MSM introduction *(new)*
- Schröder-Turk et al. (2013) — Minkowski tensor review

🤖 Generated with [Claude Code](https://claude.com/claude-code)