### PR TITLE
perf: crop to bbox in minkowski_tensors_from_label_image (#156)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Version numbers follow [Semantic Versioning](https://semver.org/).
 ### Added
 - `msm_max_l` parameter on `minkowski_tensors` and `minkowski_tensors_from_label_image` (default 8, matching C++ karambola) to control the maximum spherical harmonic order for MSM. Output arrays `msm_ql`/`msm_wl` have shape `(msm_max_l + 1,)`. The `--msm-max-l` flag exposes this option on the CLI.
 
+### Performance
+- `minkowski_tensors_from_label_image` now pre-computes per-label bounding boxes via `skimage.measure.regionprops` (one O(image_size) pass) and crops the image to each object's bounding box before calling `marching_cubes`. This eliminates the previous O(N_labels × image_size) cost and yields a ~13× wall-time speedup on a representative 77×576×576 image with 4334 labels (from ~10 min to ~0.7 min). (#156)
+
 ---
 
 ## [0.5.1] - 2026-06-14

--- a/pykarambola/api.py
+++ b/pykarambola/api.py
@@ -817,6 +817,13 @@ def minkowski_tensors_from_label_image(
             y1 = min(_shape[1], y1 + 1)
             x1 = min(_shape[2], x1 + 1)
         else:
+            warnings.warn(
+                f"Label {lab_int} not found in regionprops bounding-box cache; "
+                "falling back to full-image crop (performance may degrade). "
+                "This is unexpected - please file a bug report.",
+                RuntimeWarning,
+                stacklevel=3,
+            )
             z0, y0, x0 = 0, 0, 0
             z1, y1, x1 = _shape
         crop = label_image[z0:z1, y0:y1, x0:x1]

--- a/pykarambola/api.py
+++ b/pykarambola/api.py
@@ -763,7 +763,7 @@ def minkowski_tensors_from_label_image(
     Requires *scikit-image*.
     """
     try:
-        from skimage.measure import marching_cubes, label as sk_label
+        from skimage.measure import marching_cubes, label as sk_label, regionprops
     except ImportError:
         raise ImportError(
             "scikit-image is required for minkowski_tensors_from_label_image. "
@@ -791,6 +791,36 @@ def minkowski_tensors_from_label_image(
 
     unique_labels = np.unique(label_image)
     unique_labels = unique_labels[unique_labels != 0]
+
+    # Pre-compute per-label bounding boxes in one pass so the per-label loop
+    # can crop the image before calling marching_cubes instead of operating on
+    # the full image each time.  This is O(image_size) once rather than
+    # O(N_labels × image_size).  (#156)
+    _shape = label_image.shape
+    _sp = np.array(spacing, dtype=np.float64)
+    if len(unique_labels) > 0:
+        _label_bboxes = {p.label: p.bbox for p in regionprops(label_image)}
+    else:
+        _label_bboxes = {}
+
+    def _crop_label(lab_int):
+        """Return (cropped_float64_mask, crop_origin_physical).
+
+        crop_origin_physical is added to marching_cubes vertices (which are in
+        crop-local space) to restore full-image coordinates before subtracting
+        _pad_offset.
+        """
+        if lab_int in _label_bboxes:
+            z0, y0, x0, z1, y1, x1 = _label_bboxes[lab_int]
+            z0 = max(0, z0 - 1); y0 = max(0, y0 - 1); x0 = max(0, x0 - 1)
+            z1 = min(_shape[0], z1 + 1)
+            y1 = min(_shape[1], y1 + 1)
+            x1 = min(_shape[2], x1 + 1)
+        else:
+            z0, y0, x0 = 0, 0, 0
+            z1, y1, x1 = _shape
+        crop = label_image[z0:z1, y0:y1, x0:x1]
+        return (crop == lab_int).astype(np.float64), np.array([z0, y0, x0], dtype=np.float64) * _sp
 
     # --- autolabel=True: treat image as binary, delegate to minkowski_tensors ---
     if autolabel:
@@ -820,7 +850,8 @@ def minkowski_tensors_from_label_image(
     n_objects_total = 0
     if return_count:
         for lab in unique_labels:
-            _, n = sk_label((label_image == int(lab)), return_num=True)
+            crop_mask, _ = _crop_label(int(lab))
+            _, n = sk_label(crop_mask, return_num=True)
             n_objects_total += n
 
     # --- Compute global center upfront for center_scope='global' ---
@@ -838,11 +869,11 @@ def minkowski_tensors_from_label_image(
             all_verts_list, all_faces_list, vert_offset = [], [], 0
             for lab in unique_labels:
                 lab_int = int(lab)
-                mask = (label_image == lab_int).astype(np.float64)
+                mask, crop_origin = _crop_label(lab_int)
                 try:
                     v, f, _, _ = marching_cubes(mask, level=level, spacing=spacing,
                                                 gradient_direction='ascent')
-                    v = v - _pad_offset
+                    v = v + crop_origin - _pad_offset
                     f = _ensure_outward_normals(v, f)
                     label_meshes[lab_int] = (v, f)
                     all_verts_list.append(v)
@@ -877,14 +908,18 @@ def minkowski_tensors_from_label_image(
             cached = label_meshes[lab]
         else:
             cached = None
-        items = [(lab, (label_image == lab).astype(np.float64), cached)]
 
-        for result_key, mask, cached_mesh in items:
+        if cached is None:
+            crop_mask, crop_origin = _crop_label(lab)
+        else:
+            crop_mask = crop_origin = None
+
+        for result_key, cached_mesh in [(lab, cached)]:
             if cached_mesh is not None:
                 verts, faces = cached_mesh
             else:
                 try:
-                    verts, faces, _, _ = marching_cubes(mask, level=level, spacing=spacing,
+                    verts, faces, _, _ = marching_cubes(crop_mask, level=level, spacing=spacing,
                                                         gradient_direction='ascent')
                 except Exception as exc:
                     warnings.warn(
@@ -892,7 +927,7 @@ def minkowski_tensors_from_label_image(
                         stacklevel=2,
                     )
                     continue
-                verts = verts - _pad_offset
+                verts = verts + crop_origin - _pad_offset
                 faces = _ensure_outward_normals(verts, faces)
 
             # Determine center for this entry
@@ -912,8 +947,14 @@ def minkowski_tensors_from_label_image(
                 else:
                     label_center = centroid
             elif isinstance(center, str) and center == 'centroid_voxel':
-                voxel_coords = np.argwhere(mask > 0)  # (N, 3)
-                label_center = voxel_coords.mean(axis=0) * np.array(spacing) - _pad_offset
+                if cached_mesh is not None:
+                    # Recompute from the full image when using a cached mesh
+                    # (crop_mask is not available in this branch).
+                    voxel_coords = np.argwhere(label_image == lab)
+                    label_center = voxel_coords.mean(axis=0) * _sp - _pad_offset
+                else:
+                    voxel_coords = np.argwhere(crop_mask > 0)  # (N, 3)
+                    label_center = voxel_coords.mean(axis=0) * _sp + crop_origin - _pad_offset
             elif isinstance(center, str) and center == 'reference_centroid':
                 label_center = 'reference_centroid'
             else:


### PR DESCRIPTION
Closes #156.

## Summary

- Pre-compute per-label bounding boxes via `skimage.measure.regionprops` in one O(image_size) pass, then crop to each object's bbox (+ 1 voxel padding) before creating the float64 mask and calling `marching_cubes`.
- Eliminates the O(N_labels × image_size) bottleneck that caused `minkowski_tensors_from_label_image` to scan and allocate a full-image float64 array for every label.
- Applied to all three code paths with the bottleneck: the main per-label loop, the `return_count` loop, and the global `centroid_mesh` pre-pass.

## Performance

On a representative 77×576×576 label image (4334 labels after border removal, 2× downsampled from 154×1152×1152):

| | Before | After |
|---|---|---|
| Time per label | ~136 ms | ~10 ms |
| Extrapolated total | ~10 min | ~0.7 min |
| **Speedup** | | **~13×** |

The `regionprops` bbox precompute costs 0.07 s for all 4334 labels.

## API

No changes to the public API — same function signature, same return type, numerically identical outputs. All 203 tests pass.

## Test plan

- [x] `pytest tests/test_api.py::TestLabelImage` — 21 tests pass
- [x] `pytest` (full suite) — 203 passed, 18 skipped, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)