### PR TITLE
docs: fix unsupported KaTeX macros in minkowski_tensors.md

### DIFF
--- a/docs/minkowski_tensors.md
+++ b/docs/minkowski_tensors.md
@@ -262,7 +262,7 @@ $$
 The Minkowski Structure Metrics (MSM) are rotationally invariant scalars that quantify
 $\ell$-fold orientational order of surface normals (Steinhardt, Nelson & Ronchetti 1983;
 Mickel et al. 2013; Schröder-Turk et al. 2013). Both are computed from area-weighted spherical harmonic
-moments of face normals for $\ell = 0, \ldots, \texttt{msm\_max\_l}$ and returned only with `compute='all'`.
+moments of face normals for $\ell = 0, \ldots,$ `msm_max_l` and returned only with `compute='all'`.
 
 **Shared intermediate accumulation.**
 Let $(\theta_f, \phi_f)$ be the polar and azimuthal angles of face normal $\hat{n}_f$.
@@ -283,7 +283,7 @@ $$Q_{\ell m} = \frac{D_{\ell m}}{A\sqrt{\dfrac{4\pi}{2\ell+1}}}$$
 
 | | |
 |---|---|
-| **pykarambola key** | `msm_ql` (array shape `(msm_max_l + 1,)`, index $= \ell$, $\ell = 0,\ldots,\texttt{msm\_max\_l}$) |
+| **pykarambola key** | `msm_ql` (array shape `(msm_max_l + 1,)`, index $= \ell$, $\ell = 0,\ldots,$ `msm_max_l`) |
 | **Interpretation** | Strength of $\ell$-fold orientational order of surface normals. $q_0 = 1$ always; $q_\ell \approx 0$ for a smooth sphere; icosahedral symmetry yields a distinctive peak at $\ell = 6$. The default `msm_max_l=8` matches the karambola C++ reference implementation; pass a larger value to extend the series. MSM $q_\ell$ outperforms the plain Steinhardt bond-order parameters for characterising disordered particulate matter (Mickel et al. 2013). |
 
 Analytical definition:
@@ -313,7 +313,7 @@ where the parenthesised quantity is the Wigner 3j symbol evaluated via the Racah
 
 | | |
 |---|---|
-| **pykarambola key** | `msm_wl` (array shape `(msm_max_l + 1,)`, index $= \ell$, $\ell = 0,\ldots,\texttt{msm\_max\_l}$) |
+| **pykarambola key** | `msm_wl` (array shape `(msm_max_l + 1,)`, index $= \ell$, $\ell = 0,\ldots,$ `msm_max_l`) |
 | **Interpretation** | Phase structure of $\ell$-fold orientational order. $w_\ell = 0$ exactly for all odd $\ell$ (parity rule below). Distinguishes crystal symmetries that share the same $q_\ell$ value. |
 
 Analytical definition:
@@ -345,7 +345,7 @@ $$
 $$
 
 ($v$ is real for any closed mesh — imaginary parts cancel by the conjugation symmetry
-$D_{\ell,-m} = (-1)^m\,\overline{D_{\ell m}}$ — so $\operatorname{sgn}(\operatorname{Re}(v)) = \operatorname{sgn}(v)$.)
+$D_{\ell,-m} = (-1)^m\,\overline{D_{\ell m}}$ — so $\text{sgn}(\text{Re}(v)) = \text{sgn}(v)$.)
 
 **Parity selection rule.** For odd $\ell$, the Wigner 3j symbol above is antisymmetric
 under exchange of any two columns (each exchange contributes $(-1)^{3\ell}=-1$),


### PR DESCRIPTION
Closes #160

## Summary

- Replace `\operatorname{sgn}` / `\operatorname{Re}` with `\text{sgn}` / `\text{Re}` — `\operatorname` is not supported by GitHub's KaTeX renderer
- Move `\texttt{msm\_max\_l}` out of the three inline `$...$` math spans into backtick code spans — the `_` inside `\texttt{}` within math mode triggered the "_ allowed only in math mode" KaTeX error

## Changes

4 lines changed in `docs/minkowski_tensors.md`, no logic or content changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)